### PR TITLE
add performant labels serializer

### DIFF
--- a/metrics/api.lua
+++ b/metrics/api.lua
@@ -147,7 +147,7 @@ end
 local function labels_serializer(labels_keys)
     table.sort(labels_keys)
 
-    -- used to protect label_pairs from altering.
+    -- used to protect label_pairs from altering with unexpected keys.
     local keys_index = {}
     for _, key in ipairs(labels_keys) do
         keys_index[key] = true
@@ -155,11 +155,14 @@ local function labels_serializer(labels_keys)
 
     local function serialize(label_pairs)
         local result = ""
-        for idx, label in ipairs(labels_keys) do
-            if idx ~= 1 then
-                result = result .. '\t'
+        for _, label in ipairs(labels_keys) do
+            local value = label_pairs[label]
+            if value ~= nil then
+                if result ~= "" then
+                    result = result .. '\t'
+                end
+                result = result .. label .. '\t' .. value
             end
-            result = result .. label .. '\t' .. label_pairs[label]
         end
         return result
     end
@@ -175,7 +178,7 @@ local function labels_serializer(labels_keys)
             if not keys_index[key] then
                 error(('Label "%s" is unexpected'):format(key), 2)
             end
-            table[key] = value
+            rawset(table, key, value)
         end
     }
 

--- a/metrics/api.lua
+++ b/metrics/api.lua
@@ -143,7 +143,7 @@ end
 --- Exposed so you can write your own serializers on top of it.
 ---
 --- @param labels_keys string[] Label keys for the further use.
---- @return LabelsSerializer 
+--- @return LabelsSerializer
 local function labels_serializer(labels_keys)
     table.sort(labels_keys)
 

--- a/metrics/api.lua
+++ b/metrics/api.lua
@@ -125,6 +125,68 @@ local function set_global_labels(label_pairs)
     registry:set_labels(label_pairs)
 end
 
+--- Prepares a serializer for label pairs with given keys.
+---
+--- `make_key`, which is used during every metric-related operation, is not very efficient itself.
+--- To mitigate it, one could add his own serialization implementation.
+--- It is done via passing `__metrics_make_key` callback to the label pairs table.
+---
+--- This function gives you ready-to-use serializer, so you don't have to create one yourself.
+---
+--- BEWARE! If keys of the `label_pairs` somehow change between serialization turns, it would raise error mostlikely.
+--- Therefore, it's important to understand full scope of needed fields. For instance, for histogram:observe,
+--- an additional label 'le' is always needed.
+---
+--- @class LabelsSerializer
+--- @field wrap function(label_pairs: table): table Wraps given `label_pairs` with an efficient serialization.
+--- @field serialize function(label_pairs: table): string Serialize given `label_pairs` into the key.
+--- Exposed so you can write your own serializers on top of it.
+---
+--- @param labels_keys string[] Label keys for the further use.
+--- @return LabelsSerializer 
+local function labels_serializer(labels_keys)
+    table.sort(labels_keys)
+
+    -- used to protect label_pairs from altering.
+    local keys_index = {}
+    for _, key in ipairs(labels_keys) do
+        keys_index[key] = true
+    end
+
+    local function serialize(label_pairs)
+        local result = ""
+        for idx, label in ipairs(labels_keys) do
+            if idx ~= 1 then
+                result = result .. '\t'
+            end
+            result = result .. label .. '\t' .. label_pairs[label]
+        end
+        return result
+    end
+
+    local pairs_metatable = {
+        __index = {
+            __metrics_make_key = function(self)
+                return serialize(self)
+            end
+        },
+        -- It protects pairs from being altered with unexpected labels.
+        __newindex = function(table, key, value)
+            if not keys_index[key] then
+                error(('Label "%s" is unexpected'):format(key), 2)
+            end
+            table[key] = value
+        end
+    }
+
+    return {
+        wrap = function(label_pairs)
+            return setmetatable(label_pairs, pairs_metatable)
+        end,
+        serialize = serialize
+    }
+end
+
 return {
     registry = registry,
     collectors = collectors,
@@ -140,4 +202,5 @@ return {
     unregister_callback = unregister_callback,
     invoke_callbacks = invoke_callbacks,
     set_global_labels = set_global_labels,
+    labels_serializer = labels_serializer
 }

--- a/metrics/collectors/shared.lua
+++ b/metrics/collectors/shared.lua
@@ -47,6 +47,10 @@ function Shared.make_key(label_pairs)
     if type(label_pairs) ~= 'table' then
         return ""
     end
+    -- `label_pairs` provides its own serialization scheme, it must be used instead of default one.
+    if label_pairs.__metrics_make_key then
+        return label_pairs:__metrics_make_key()
+    end
     local parts = {}
     for k, v in pairs(label_pairs) do
         table.insert(parts, k .. '\t' .. v)

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -27,6 +27,7 @@ return setmetatable({
     unregister_callback = api.unregister_callback,
     invoke_callbacks = api.invoke_callbacks,
     set_global_labels = api.set_global_labels,
+    labels_serializer = api.labels_serializer,
     enable_default_metrics = tarantool.enable,
     cfg = cfg.cfg,
     http_middleware = http_middleware,

--- a/test/metrics_test.lua
+++ b/test/metrics_test.lua
@@ -5,7 +5,6 @@ local g = t.group('collectors')
 
 local metrics = require('metrics')
 local utils = require('test.utils')
-local json = require("json")
 
 g.before_all(utils.create_server)
 g.after_all(utils.drop_server)
@@ -303,13 +302,13 @@ g.test_labels_serializer_consistent = function()
 
     -- after we add the needed key, hist:observe should work.
     table.insert(label_keys, "le")
-    local serializer = metrics.labels_serializer(label_keys)
-    local hist = metrics.histogram('hist2', 'test histogram 2', {2})
+    local hist_serializer = metrics.labels_serializer(label_keys)
+    local hist2 = metrics.histogram('hist2', 'test histogram 2', {2})
 
-    hist:observe(3, serializer.wrap(table.copy(label_pairs)))
-    local state = table.deepcopy(hist)
-    hist:observe(3, label_pairs)
+    hist2:observe(3, hist_serializer.wrap(table.copy(label_pairs)))
+    local state = table.deepcopy(hist2)
+    hist2:observe(3, label_pairs)
 
-    t.assert_equals(hist.observations, state.observations)
-    t.assert_equals(hist.label_pairs, state.label_pairs)
+    t.assert_equals(hist2.observations, state.observations)
+    t.assert_equals(hist2.label_pairs, state.label_pairs)
 end


### PR DESCRIPTION
`make_key` is not very efficient itself, so special `labels_serializer` is added with optimized scheme.